### PR TITLE
Updated composer package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ file format that stores data indexed by IP address subnets (IPv4 or IPv6).
 ### Define Your Dependencies ###
 
 We recommend installing this package with [Composer](http://getcomposer.org/).
-To do this, add ```maxminddb/reader``` to your ```composer.json``` file.
+To do this, add ```maxmind-db/reader``` to your ```composer.json``` file.
 
 ```json
 {
     "require": {
-        "maxminddb/reader": "dev-master"
+        "maxmind-db/reader": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
Fixed the wrong composer package name.

Anyway, I think it should be named `maxmind/dbreader` or `maxmind/db-reader` instead to follow the usual package naming with vendor name before the slash.
