### PR TITLE
Addressed syntax errors in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ use MaxMind\Db\Reader;
 $ipAddress = '24.24.24.24';
 $databaseFile = 'GeoIP2-City.mmdb';
 
-$reader = new Reader('GeoIP2-City.mmdb');
+$reader = new Reader($databaseFile);
 
-print_r $reader->get($ip);
-...
+print_r ($reader->get($ipAddress));
+//...
 ```
 
 ## Support ##


### PR DESCRIPTION
$ipAddress is now used consistently.
$databaseFile is now used.
print_r requires brackets
Commented out ...
