### PR TITLE
Update composer.json to require bcmath

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
             "homepage": "http://www.maxmind.com/"
         }
     ],
+    "require":{
+        "ext-bcmath":"*",
+        "php":">=5.3.1"
+    },
     "require-dev": {
         "phpunit/phpunit": "3.7.*",
         "satooshi/php-coveralls": "dev-master"


### PR DESCRIPTION
I tried running GeoIP2 on a box without the BC Math PHP extension and got the error:

Fatal error: Call to undefined function MaxMind\Db\Reader\bcadd() in /home/vagrant/Akkroo/publish/vendor/maxmind-db/reader/src/MaxMind/Db/Reader/Decoder.php on line 252

The library should depend on ext-bcmath to ensure users do not run in to this problem.

Additionally, the package did not depend on a specific minimum version of PHP.  I assumed the same version as the GeoIP2 package.
