### PR TITLE
Do not use strlen ever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+1.0.3 (2015-XX-XX)
+------------------
+
+* All uses of `strlen` were removed. This should prevent issues in situations
+  where the function was overloaded or otherwise broken.
+
 1.0.2 (2015-01-19)
 ------------------
 

--- a/src/MaxMind/Db/Reader.php
+++ b/src/MaxMind/Db/Reader.php
@@ -13,8 +13,9 @@ use MaxMind\Db\Reader\Util;
  */
 class Reader
 {
-    private $DATA_SECTION_SEPARATOR_SIZE = 16;
-    private $METADATA_START_MARKER = "\xAB\xCD\xEFMaxMind.com";
+    private static $DATA_SECTION_SEPARATOR_SIZE = 16;
+    private static $METADATA_START_MARKER = "\xAB\xCD\xEFMaxMind.com";
+    private static $METADATA_START_MARKER_LENGTH = 14;
 
     private $decoder;
     private $fileHandle;
@@ -65,7 +66,7 @@ class Reader
         $this->metadata = new Metadata($metadataArray);
         $this->decoder = new Decoder(
             $this->fileHandle,
-            $this->metadata->searchTreeSize + $this->DATA_SECTION_SEPARATOR_SIZE
+            $this->metadata->searchTreeSize + self::$DATA_SECTION_SEPARATOR_SIZE
         );
     }
 
@@ -234,8 +235,8 @@ class Reader
         $handle = $this->fileHandle;
         $fstat = fstat($handle);
         $fileSize = $fstat['size'];
-        $marker = $this->METADATA_START_MARKER;
-        $markerLength = Util::stringLength($marker);
+        $marker = self::$METADATA_START_MARKER;
+        $markerLength = self::$METADATA_START_MARKER_LENGTH;
 
         for ($i = 0; $i < $fileSize - $markerLength + 1; $i++) {
             for ($j = 0; $j < $markerLength; $j++) {

--- a/src/MaxMind/Db/Reader/Decoder.php
+++ b/src/MaxMind/Db/Reader/Decoder.php
@@ -129,7 +129,7 @@ class Decoder
                 return array($this->decodeInt32($bytes), $newOffset);
             case 'uint64':
             case 'uint128':
-                return array($this->decodeBigUint($bytes), $newOffset);
+                return array($this->decodeBigUint($bytes, $size), $newOffset);
             default:
                 throw new InvalidDatabaseException(
                     "Unknown or unexpected type: " . $type
@@ -229,10 +229,10 @@ class Decoder
         return $int;
     }
 
-    private function decodeBigUint($bytes)
+    private function decodeBigUint($bytes, $byteLength)
     {
         $maxUintBytes = log(PHP_INT_MAX, 2) / 8;
-        $byteLength = Util::stringLength($bytes);
+
         if ($byteLength == 0) {
             return 0;
         }

--- a/src/MaxMind/Db/Reader/Util.php
+++ b/src/MaxMind/Db/Reader/Util.php
@@ -6,7 +6,6 @@ use MaxMind\Db\Reader\InvalidDatabaseException;
 
 class Util
 {
-
     public static function read($stream, $offset, $numberOfBytes)
     {
         if ($numberOfBytes == 0) {
@@ -25,14 +24,5 @@ class Util
         throw new InvalidDatabaseException(
             "The MaxMind DB file contains bad data"
         );
-    }
-
-    public static function stringLength($string)
-    {
-        if (function_exists('mb_strlen')) {
-            return mb_strlen($string, '8bit');
-        }
-
-        return strlen($string);
     }
 }


### PR DESCRIPTION
Previously we tried detecting if mbstring was in use and use mb_strlen
with '8bit' encoding if it was. However, we still occasionally received
reports of invalid database exceptions due to `strlen` returning
incorrect lengths. In 1.0.0 we removed most uses of this function. This
removes the few remaining uses.