### PR TITLE
Remove final keyword from C extension Reader class

### DIFF
--- a/ext/maxminddb.c
+++ b/ext/maxminddb.c
@@ -535,7 +535,6 @@ PHP_MINIT_FUNCTION(maxminddb){
     INIT_CLASS_ENTRY(ce, PHP_MAXMINDDB_READER_NS, maxminddb_methods);
     maxminddb_ce = zend_register_internal_class(&ce TSRMLS_CC);
     maxminddb_ce->create_object = maxminddb_create_handler;
-    maxminddb_ce->ce_flags |= ZEND_ACC_FINAL;
     memcpy(&maxminddb_obj_handlers,
            zend_get_std_object_handlers(), sizeof(zend_object_handlers));
     maxminddb_obj_handlers.clone_obj = NULL;

--- a/ext/tests/001-load.phpt
+++ b/ext/tests/001-load.phpt
@@ -5,7 +5,7 @@ Check for maxminddb presence
     echo 'skip';
 } ?>
 --FILE--
-<?php 
+<?php
 echo 'maxminddb extension is available';
 ?>
 --EXPECT--

--- a/ext/tests/002-final.phpt
+++ b/ext/tests/002-final.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Check that Reader class is not final
+--SKIPIF--
+<?php if (!extension_loaded('maxminddb')) {
+    echo 'skip';
+} ?>
+--FILE--
+<?php
+$reflectionClass = new \ReflectionClass('MaxMind\Db\Reader');
+var_dump($reflectionClass->isFinal());
+?>
+--EXPECT--
+bool(false)

--- a/tests/MaxMind/Db/Test/ReaderTest.php
+++ b/tests/MaxMind/Db/Test/ReaderTest.php
@@ -288,6 +288,12 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $reader->metadata();
     }
 
+    public function testReaderIsNotFinal()
+    {
+        $reflectionClass = new \ReflectionClass('MaxMind\Db\Reader');
+        $this->assertFalse($reflectionClass->isFinal());
+    }
+
     private function checkMetadata($reader, $ipVersion, $recordSize)
     {
         $metadata = $reader->metadata();


### PR DESCRIPTION
This PR should ensure that the Reader class from the PHP library and C extension match. 

But I'm not sure the current testing setup works as expected (I might be totally wrong about this), but while running Travis in my fork I noticed that the PHPUnit test did not pass (altough the class was not marked final in the lib), probably because before running the PHP library tests, we're installing the C extension which will then be used by PHPUnit. Only after fixing the C extension did the test pass.

Fixes #52 