### PR TITLE
composer.json: accept "5.*" versions of PHPUnit in addition to "4.*"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.*",
-        "phpunit/phpunit": "4.*",
+        "phpunit/phpunit": "4.* || 5.*",
         "satooshi/php-coveralls": "1.0.*",
         "squizlabs/php_codesniffer": "3.*"
     },


### PR DESCRIPTION
Closes: https://github.com/maxmind/MaxMind-DB-Reader-php/issues/57