### PR TITLE
HHVM wording in GeoIP2 PHP API requirements is clarified

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ client API, please see [our support page](http://www.maxmind.com/en/support).
 
 ## Requirements  ##
 
-This library requires PHP 5.4 or greater. The pure PHP reader included with
-this library works and is tested with HHVM.
+This library requires PHP 5.4 or greater. The pure PHP reader included is
+compatible with HHVM.
 
 The GMP or BCMath extension may be required to read some databases
 using the pure PHP API.
@@ -151,6 +151,6 @@ The MaxMind DB Reader PHP API uses [Semantic Versioning](http://semver.org/).
 
 ## Copyright and License ##
 
-This software is Copyright (c) 2014-2017 by MaxMind, Inc.
+This software is Copyright (c) 2014-2018 by MaxMind, Inc.
 
 This is free software, licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
PT #157667907; I used the same branch name as the one for GeoIP-PHP. This is under MaxMind-DB-Reader-PHP. Hopefully it doesn't cause any confusion. 