### PR TITLE
Prevent overflowing of uint32 values on 32 bit machines when using the extension

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,6 +8,7 @@ return PhpCsFixer\Config::create()
         'array_syntax' => ['syntax' => 'short'],
         'combine_consecutive_unsets' => true,
         'concat_space' => [ 'spacing' => 'one'],
+        'fopen_flags' => ['b_mode' => true],
         'heredoc_to_nowdoc' => true,
         'list_syntax' => ['syntax' => 'long'],
         'no_extra_consecutive_blank_lines' => ['break', 'continue', 'extra', 'return', 'throw', 'use', 'parenthesis_brace_block', 'square_brace_block', 'curly_brace_block'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 CHANGELOG
 =========
 
+1.4.1
+------------------
+
+* The `maxminddb` extension now returns a string when a `uint32`
+  value is greater than `LONG_MAX`. Previously, the value would
+  overflow. This generally only affects 32-bit machines.  Reported
+  by Remi Collet. GitHub #79.
+* For `uint64` values, the `maxminddb` extension now returns an
+  integer rather than a string when the value is less than or equal
+  to `LONG_MAX`. This more closely matches the behavior of the pure
+  PHP reader.
+
 1.4.0 (2018-11-20)
 ------------------
 


### PR DESCRIPTION
Closes #79