### PR TITLE
Remove hhvm support from readme/travis config & scripts

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -3,15 +3,12 @@
 set -e
 set -x
 
-if [ "hhvm" != $TRAVIS_PHP_VERSION ]
-then
-  export CFLAGS="-L$HOME/libmaxminddb/lib"
-  export CPPFLAGS="-I$HOME/libmaxminddb/include"
-  cd ext
-  phpize
-  ./configure --with-maxminddb --enable-maxminddb-debug
-  make clean
-  make
-  NO_INTERACTION=1 make test
-  cd ..
-fi
+export CFLAGS="-L$HOME/libmaxminddb/lib"
+export CPPFLAGS="-I$HOME/libmaxminddb/include"
+cd ext
+phpize
+./configure --with-maxminddb --enable-maxminddb-debug
+make clean
+make
+NO_INTERACTION=1 make test
+cd ..

--- a/.travis-install-prereqs.sh
+++ b/.travis-install-prereqs.sh
@@ -6,13 +6,10 @@ set -x
 git submodule update --init --recursive
 composer self-update
 composer install --dev -n --prefer-source
-if [ "hhvm" != "$TRAVIS_PHP_VERSION" ]
-then
-  mkdir -p "$HOME/libmaxminddb"
-  git clone --recursive git://github.com/maxmind/libmaxminddb
-  cd libmaxminddb
-  ./bootstrap
-  ./configure --prefix="$HOME/libmaxminddb"
-  make
-  make install
-fi
+mkdir -p "$HOME/libmaxminddb"
+git clone --recursive git://github.com/maxmind/libmaxminddb
+cd libmaxminddb
+./bootstrap
+./configure --prefix="$HOME/libmaxminddb"
+make
+make install

--- a/.travis-test.sh
+++ b/.travis-test.sh
@@ -6,15 +6,12 @@ set -x
 mkdir -p build/logs
 ./vendor/bin/phpunit -c .coveralls-phpunit.xml.dist
 
-if [ "hhvm" != "$TRAVIS_PHP_VERSION" ]
-then
-    echo "mbstring.internal_encoding=utf-8" >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/php.ini
-    echo "mbstring.func_overload = 7" >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/php.ini
-    ./vendor/bin/phpunit
+echo "mbstring.internal_encoding=utf-8" >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/php.ini
+echo "mbstring.func_overload = 7" >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/php.ini
+./vendor/bin/phpunit
 
-    echo "extension = ext/modules/maxminddb.so" >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/php.ini
-    ./vendor/bin/phpunit
-fi
+echo "extension = ext/modules/maxminddb.so" >> ~/.phpenv/versions/"$(phpenv version-name)"/etc/php.ini
+./vendor/bin/phpunit
 
 if [ $RUN_LINTER ]; then
     vendor/bin/php-cs-fixer fix --verbose --diff --dry-run --config=.php_cs

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1
-    - php: hhvm
 env:
   global:
     - secure: "RMIBN2tNKlrGA07coRW4B9m9jCobrYxDkEq3T3jGoGtXgQe/Mr3bI/4zQo7U3bvVTSF90lzkWbxATY45GQXRxWC7Ed2HI2jwUF96CXecdRhKiE9x051HsvXakvbODPLocV7/2LOZqz+eXCUeazLgRaSrIhAqMddFqMQSSM5STlc="

--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ client API, please see [our support page](http://www.maxmind.com/en/support).
 
 ## Requirements  ##
 
-This library requires PHP 5.4 or greater. The pure PHP reader included is
-compatible with HHVM.
+This library requires PHP 5.4 or greater.
 
 The GMP or BCMath extension may be required to read some databases
 using the pure PHP API.


### PR DESCRIPTION
HHVM 4.0 is released and the version that travis runs, and it [no longer supports php](https://hhvm.com/blog/2018/09/12/end-of-php-support-future-of-hack.html).