### PR TITLE
PHP 8 compatibility fixes

### DIFF
--- a/.travis-install-prereqs.sh
+++ b/.travis-install-prereqs.sh
@@ -3,9 +3,14 @@
 set -e
 set -x
 
+COMPOSER_FLAGS="--dev -n --prefer-source"
+if [ "$TRAVIS_PHP_VERSION" = "7.4" ] || [ "$TRAVIS_PHP_VERSION" = "8.0" ] || [ "$TRAVIS_PHP_VERSION" = "master" ]; then
+    COMPOSER_FLAGS="$COMPOSER_FLAGS --ignore-platform-reqs"
+fi
+
 git submodule update --init --recursive
 composer self-update
-composer install --dev -n --prefer-source
+composer install $COMPOSER_FLAGS
 mkdir -p "$HOME/libmaxminddb"
 git clone --recursive git://github.com/maxmind/libmaxminddb
 cd libmaxminddb

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,11 @@ matrix:
       env:
         - RUN_LINTER=1
         - RUN_SNYK=1
+    - php: master
+  fast_finish: true
+  allow_failures:
+    - php: 'master'
+
 env:
   global:
     - secure: "RMIBN2tNKlrGA07coRW4B9m9jCobrYxDkEq3T3jGoGtXgQe/Mr3bI/4zQo7U3bvVTSF90lzkWbxATY45GQXRxWC7Ed2HI2jwUF96CXecdRhKiE9x051HsvXakvbODPLocV7/2LOZqz+eXCUeazLgRaSrIhAqMddFqMQSSM5STlc="

--- a/ext/maxminddb.c
+++ b/ext/maxminddb.c
@@ -50,6 +50,20 @@ typedef int strsize_t;
 typedef void free_obj_t;
 #endif
 
+/* For PHP 8 compatibility */
+#ifndef TSRMLS_C
+#define TSRMLS_C
+#endif
+#ifndef TSRMLS_CC
+#define TSRMLS_CC
+#endif
+#ifndef TSRMLS_DC
+#define TSRMLS_DC
+#endif
+#ifndef ZEND_ACC_CTOR
+#define ZEND_ACC_CTOR 0
+#endif
+
 #ifdef ZEND_ENGINE_3
 typedef struct _maxminddb_obj {
     MMDB_s *mmdb;
@@ -274,7 +288,14 @@ PHP_METHOD(MaxMind_Db_Reader, metadata){
 
     handle_entry_data_list(entry_data_list, metadata_array TSRMLS_CC);
     MMDB_free_entry_data_list(entry_data_list);
-#ifdef ZEND_ENGINE_3
+#if PHP_VERSION_ID >= 80000
+    zend_call_method_with_1_params(Z_OBJ_P(return_value), metadata_ce,
+                                   &metadata_ce->constructor,
+                                   ZEND_CONSTRUCTOR_FUNC_NAME,
+                                   NULL,
+                                   metadata_array);
+    zval_ptr_dtor(metadata_array);
+#elif defined(ZEND_ENGINE_3)
     zend_call_method_with_1_params(return_value, metadata_ce,
                                    &metadata_ce->constructor,
                                    ZEND_CONSTRUCTOR_FUNC_NAME,


### PR DESCRIPTION
- Shim TSRMLS_* constants
- Fix for changes to zend_call_method API (zval -> zend_object)
