### PR TITLE
MMDB_LIB_VERSION

### DIFF
--- a/ext/maxminddb.c
+++ b/ext/maxminddb.c
@@ -665,6 +665,7 @@ PHP_MINIT_FUNCTION(maxminddb) {
     maxminddb_obj_handlers.offset = XtOffsetOf(maxminddb_obj, std);
     maxminddb_obj_handlers.free_obj = maxminddb_free_storage;
 #endif
+    zend_declare_class_constant_string(maxminddb_ce, "MMDB_LIB_VERSION", sizeof("MMDB_LIB_VERSION")-1, MMDB_lib_version() TSRMLS_CC);
 
     return SUCCESS;
 }

--- a/tests/MaxMind/Db/Test/ReaderTest.php
+++ b/tests/MaxMind/Db/Test/ReaderTest.php
@@ -243,6 +243,9 @@ class ReaderTest extends PHPUnit_Framework_TestCase
      */
     public function testV6AddressV4Database()
     {
+        if (defined("MaxMind\\Db\\Reader::MMDB_LIB_VERSION") && version_compare(Reader::MMDB_LIB_VERSION, '1.2.0', '<')) {
+            $this->markTestSkipped('MMDB_LIB_VERSION < 1.2.0');
+        }
         $reader = new Reader('tests/data/test-data/MaxMind-DB-test-ipv4-24.mmdb');
         $reader->get('2001::');
     }


### PR DESCRIPTION
Digging why test suite fail on old RHEL / CentOS 6
```
+ php --define extension=/builddir/build/BUILDROOT/php-maxminddb-1.5.0-1.el6.remi17.0.x86_64/usr/lib64/php/modules/maxminddb.so /usr/bin/phpunit --bootstrap /builddir/build/BUILDROOT/php-maxminddb-1.5.0-1.el6.remi17.0.x86_64/usr/share/php/MaxMind/Db/Reader/autoload.php --verbose
PHPUnit 5.7.27 by Sebastian Bergmann and contributors.
Runtime:       PHP 7.0.33
Configuration: /builddir/build/BUILD/MaxMind-DB-Reader-php-bd436094fc0a9b0558a899fb80b0ae34fe1808a0/phpunit.xml.dist
....................F................                             37 / 37 (100%)
Time: 39 ms, Memory: 13.00MB
There was 1 failure:
1) MaxMind\Db\Test\Reader\ReaderTest::testV6AddressV4Database
Failed asserting that exception of type "\InvalidArgumentException" is thrown.
FAILURES!
Tests: 37, Assertions: 363, Failures: 1.
```

I found this is related to libmaxmindb 1.1.1 in EPEL
https://apps.fedoraproject.org/packages/libmaxminddb

This PR simply expose the `MaxMind\\Db\\Reader::MMDB_LIB_VERSION` to userland, and thus allow to skip this test (can probably be use later for future change in the library).

