### PR TITLE
Test enhancement

### DIFF
--- a/.coveralls-phpunit.xml.dist
+++ b/.coveralls-phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="MaxMind DB Test Suite">
             <directory suffix="Test.php">./tests/MaxMind/Db/Test/</directory>

--- a/.php_cs
+++ b/.php_cs
@@ -25,6 +25,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_order' => true,
         'phpdoc_to_comment' => false,
         'semicolon_after_instruction' => true,
+        'single_line_throw' => false,
         'strict_comparison' => true,
         'strict_param' => true,
         'yoda_style' => false,

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
         "psr-4": {
             "MaxMind\\Db\\": "src/MaxMind/Db"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MaxMind\\Db\\Test\\Reader\\": "tests/MaxMind/Db/Test/Reader"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="MaxMind DB Test Suite">
             <directory suffix="Test.php">./tests/MaxMind/Db/Test/</directory>

--- a/tests/MaxMind/Db/Test/Reader/DecoderTest.php
+++ b/tests/MaxMind/Db/Test/Reader/DecoderTest.php
@@ -3,12 +3,12 @@
 namespace MaxMind\Db\Test\Reader;
 
 use MaxMind\Db\Reader\Decoder;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class DecoderTest extends PHPUnit_Framework_TestCase
+class DecoderTest extends TestCase
 {
     private $arrays = [
         [

--- a/tests/MaxMind/Db/Test/Reader/PointerTest.php
+++ b/tests/MaxMind/Db/Test/Reader/PointerTest.php
@@ -3,12 +3,12 @@
 namespace MaxMind\Db\Test\Reader;
 
 use MaxMind\Db\Reader\Decoder;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversNothing
  */
-class PointerTest extends PHPUnit_Framework_TestCase
+class PointerTest extends TestCase
 {
     public function testWithPointers()
     {

--- a/tests/MaxMind/Db/Test/ReaderTest.php
+++ b/tests/MaxMind/Db/Test/ReaderTest.php
@@ -4,13 +4,13 @@ namespace MaxMind\Db\Test\Reader;
 
 use InvalidArgumentException;
 use MaxMind\Db\Reader;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
  * @coversNothing
  */
-class ReaderTest extends PHPUnit_Framework_TestCase
+class ReaderTest extends TestCase
 {
     public function testReader()
     {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require __DIR__ . '/../autoload.php';


### PR DESCRIPTION
# Changed log
- Add the `-n` option to let `PHP_CodeSniffer` ignore warning message output.
- Add the `autoload-dev` to load test classes automatically.
- Using the `PHPUnit` class namespace.
- Applying the coding style changes via `php-cs-fixer` style fix.