### PR TITLE
PHP Built-In Functions + UNC Path Bug

### DIFF
--- a/src/MaxMind/Db/Reader.php
+++ b/src/MaxMind/Db/Reader.php
@@ -48,7 +48,17 @@ class Reader
             );
         }
 
-        if (!is_readable($database)) {
+        // If UNC path...
+        if (substr($database, 0, 2) === str_repeat(DIRECTORY_SEPARATOR, 2)) {
+
+            $readable = file_exists($root);
+
+        } else {
+
+            $readable = is_readable($root);
+        }
+
+        if (!readable) {
             throw new InvalidArgumentException(
                 "The file \"$database\" does not exist or is not readable."
             );

--- a/src/MaxMind/Db/Reader.php
+++ b/src/MaxMind/Db/Reader.php
@@ -51,14 +51,14 @@ class Reader
         // If UNC path...
         if (substr($database, 0, 2) === str_repeat(DIRECTORY_SEPARATOR, 2)) {
 
-            $readable = file_exists($root);
+            $readable = file_exists($database);
 
         } else {
 
-            $readable = is_readable($root);
+            $readable = is_readable($database);
         }
 
-        if (!readable) {
+        if (!$readable) {
             throw new InvalidArgumentException(
                 "The file \"$database\" does not exist or is not readable."
             );


### PR DESCRIPTION
In certain PHP releases, there's a known issue (https://bugs.php.net/bug.php?id=62199) in PHP's built-in `is_readable()` function and the use of SMB file shares. The PHP built-in `is_writable()` function, alias `is_writeable()`, is similarly affected.

These functions incorrectly return `FALSE` for a given UNC file path even though the target is, in fact, readable in the case `is_readable()`, or writable in the case of `is_writable()`.

Until such a time as this bug is fixed, I'd like to suggest a small work-around (or something like it) for the most reliable use of UNC paths in the `MaxMind\Db\Reader` class.

Reference:
* https://www.php.net/manual/en/function.is-readable.php
* https://www.php.net/manual/en/function.is-writable.php
* https://www.php.net/manual/en/function.is-writeable.php
* https://bugs.php.net/bug.php?id=62199