### PR TITLE
Add composer.json conflict section

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "ext-gmp": "bcmath or gmp is required for decoding larger integers with the pure PHP decoder",
         "ext-maxminddb": "A C-based database decoder that provides significantly faster lookups"
     },
+    "conflict": {
+	"ext-maxminddb": "<1.5.1,>2"
+    },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "2.*",
         "phpunit/phpunit": "5.*",


### PR DESCRIPTION
On production servers, I have a slightly outdated version 1.4.0 of `maxminddb` extension.

I updated dependencies using normal `composer update` operation.
Composer updated package `maxmind-db/reader` from 1.4.0 to 1.5.1 and also upgraded `geoip2/geoip2` library

I now have production errors as geoip2 is using 1.5 added method `getWithPrefixLen()`.

I will update C extension but the process is heavier than just a PHP package.

To avoid this situation, I think composer.json should contain a conflict section with incompatible versions.

Current version of library: 1.5.1:
```json
{
  "conflict": {
    "ext-maxminddb": "<1.5.1,>=2"
  }
}
```

This conflicts section MUST be changed for each version of the library. Also, it will only be effective from now on and I think a Release Note should be added to the ReadMe section about the C extension.