### PR TITLE
Add config.w32 for building on Windows

### DIFF
--- a/ext/config.w32
+++ b/ext/config.w32
@@ -5,6 +5,6 @@ if (PHP_MAXMINDDB == "yes") {
 		CHECK_LIB("libmaxminddb.lib", "maxminddb", PHP_MAXMINDDB)) {
 		EXTENSION("maxminddb", "maxminddb.c");
 	} else {
-		WARNING('Could not find maxminddb.h or libmaxminddb lib; skipping');
+		WARNING('Could not find maxminddb.h or libmaxminddb.lib; skipping');
 	}
 }

--- a/ext/config.w32
+++ b/ext/config.w32
@@ -1,0 +1,12 @@
+// vim:ft=javascript
+
+ARG_WITH("maxminddb", "Enable MaxMind DB Reader extension support", "no");
+
+if (PHP_MAXMINDDB == "yes") {
+	if (CHECK_HEADER_ADD_INCLUDE("maxminddb.h", "CFLAGS_MAXMINDDB", PHP_MAXMINDDB +  ";" + PHP_PHP_BUILD + "\\include\\maxminddb") &&
+		CHECK_LIB("libmaxminddb.lib", "maxminddb", PHP_MAXMINDDB)) {
+		EXTENSION("maxminddb", "maxminddb.c");
+	} else {
+		WARNING('Could not find maxminddb.h or maxminddb lib; skipping');
+	}
+}

--- a/ext/config.w32
+++ b/ext/config.w32
@@ -1,5 +1,3 @@
-// vim:ft=javascript
-
 ARG_WITH("maxminddb", "Enable MaxMind DB Reader extension support", "no");
 
 if (PHP_MAXMINDDB == "yes") {
@@ -7,6 +5,6 @@ if (PHP_MAXMINDDB == "yes") {
 		CHECK_LIB("libmaxminddb.lib", "maxminddb", PHP_MAXMINDDB)) {
 		EXTENSION("maxminddb", "maxminddb.c");
 	} else {
-		WARNING('Could not find maxminddb.h or maxminddb lib; skipping');
+		WARNING('Could not find maxminddb.h or libmaxminddb lib; skipping');
 	}
 }

--- a/ext/maxminddb.c
+++ b/ext/maxminddb.c
@@ -431,7 +431,7 @@ handle_map(const MMDB_entry_data_list_s *entry_data_list,
     array_init(z_value);
     const uint32_t map_size = entry_data_list->entry_data.data_size;
 
-    uint i;
+    uint32_t i;
     for (i = 0; i < map_size && entry_data_list; i++) {
         entry_data_list = entry_data_list->next;
 
@@ -463,7 +463,7 @@ handle_array(const MMDB_entry_data_list_s *entry_data_list,
 
     array_init(z_value);
 
-    uint i;
+    uint32_t i;
     for (i = 0; i < size && entry_data_list; i++) {
         entry_data_list = entry_data_list->next;
         zval new_value;

--- a/package.xml
+++ b/package.xml
@@ -33,6 +33,7 @@
 
             <dir name="ext">
                 <file role="src" name="config.m4"/>
+                <file role="src" name="config.w32"/>
 
                 <file role="src" name="maxminddb.c"/>
                 <file role="src" name="php_maxminddb.h"/>


### PR DESCRIPTION
This is a minimal config.w32 for building php_maxminddb.dll on Windows.
Tests with a GeoIP2-City.mmdb in \usr\local\share\GeoIP
```
=====================================================================
Number of tests :    3                 3
Tests skipped   :    0 (  0.0%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Expected fail   :    0 (  0.0%) (  0.0%)
Tests passed    :    3 (100.0%) (100.0%)
---------------------------------------------------------------------
Time taken      :    0 seconds
=====================================================================
```
It works for PHP 7.0 - 7.4 and PHP 8.0, provided the libmaxminddb dependencies are in deps/lib and deps/include. Please review and merge.

See a phpinfo dump:
https://phpdev.toolsforresearch.com/php-8.0.1RC1-nts-Win32-vs16-x64.htm

And the complete distro
https://phpdev.toolsforresearch.com/php-8.0.1RC1-nts-Win32-vs16-x64.zip