### PR TITLE
Remove runtime define of constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 CHANGELOG
 =========
 
-1.10.2
+1.11.0
 -------------------
 
+* Replace runtime define of a constant to facilitate opcache preloading.
+  Reported by vedadkajtaz. GitHub #134.
 * Resolve minor issue found by the Clang static analyzer in the C
   extension.
 

--- a/src/MaxMind/Db/Reader/Decoder.php
+++ b/src/MaxMind/Db/Reader/Decoder.php
@@ -7,13 +7,6 @@ namespace MaxMind\Db\Reader;
 // @codingStandardsIgnoreLine
 use RuntimeException;
 
-/*
- * @ignore
- *
- * We subtract 1 from the log to protect against precision loss.
- */
-\define(__NAMESPACE__ . '\_MM_MAX_INT_BYTES', (int) ((log(\PHP_INT_MAX, 2) - 1) / 8));
-
 class Decoder
 {
     /**
@@ -316,11 +309,11 @@ class Decoder
 
         $integer = 0;
 
-        // PHP integers are signed. _MM_MAX_INT_BYTES is the number of
+        // PHP integers are signed. PHP_INT_SIZE - 1 is the number of
         // complete bytes that can be converted to an integer. However,
         // we can convert another byte if the leading bit is zero.
-        $useRealInts = $byteLength <= _MM_MAX_INT_BYTES
-            || ($byteLength === _MM_MAX_INT_BYTES + 1 && (\ord($bytes[0]) & 0x80) === 0);
+        $useRealInts = $byteLength <= \PHP_INT_SIZE - 1
+            || ($byteLength === \PHP_INT_SIZE && (\ord($bytes[0]) & 0x80) === 0);
 
         for ($i = 0; $i < $byteLength; ++$i) {
             $part = \ord($bytes[$i]);


### PR DESCRIPTION
I am not sure why we didn't use PHP_INT_SIZE in the first place.
Using log is too clever and doesn't accomplish much.

Closes #134.
