### PR TITLE
Run apt update before apt install

### DIFF
--- a/.github/workflows/clang-addresssanitizer.yml
+++ b/.github/workflows/clang-addresssanitizer.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: true
 
       - name: Install system dependencies
-        run: sudo apt install pkg-config clang build-essential libxml2-dev libsqlite3-dev wget libssl-dev libcurl4 zlib1g-dev libcurl4-openssl-dev libonig-dev libzip-dev -y
+        run: sudo apt update && sudo apt install pkg-config clang build-essential libxml2-dev libsqlite3-dev wget libssl-dev libcurl4 zlib1g-dev libcurl4-openssl-dev libonig-dev libzip-dev -y
 
       # We install PHP from source as I was unsuccessful building only the
       # extension with AddressSanitizer and getting that to run.

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -24,7 +24,7 @@ jobs:
           submodules: true
 
       - name: Install clang-tools and libmaxminddb
-        run: sudo apt-get install clang-tools libmaxminddb-dev
+        run: sudo apt update && sudo apt-get install clang-tools libmaxminddb-dev
 
       - name: Build extension
         run: |


### PR DESCRIPTION
To prevent 404s from versions that are no longer available.
