### PR TITLE
Reenable i386 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     container: shivammathur/node:latest-${{ matrix.arch }}
     strategy:
       matrix:
-        arch: ["amd64"]
+        arch: ["amd64", "i386"]
         operating-system: [ubuntu-latest]
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         php-extensions: ['bcmath', 'gmp']


### PR DESCRIPTION
As of https://github.com/shivammathur/node-docker/commit/0c55baf6ab661edbd285c1e245224f3bab6c9e2b, the Docker images support extensions again.