### PR TITLE
Release 1.12.0

### DIFF
--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.4
           tools: composer, phpize
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ jobs:
         operating-system: [ubuntu-latest]
         php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         php-extensions: ['bcmath', 'gmp']
+        exclude:
+          # We are getting weird libxml2 failures on this combo
+          - arch: "i386"
+            php-versions: 8.4
+
     name: "PHP ${{ matrix.php-versions }} (with ${{ matrix.php-extensions }}) test on ${{ matrix.operating-system }}/${{ matrix.arch }}"
     steps:
       - name: Install PHP

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,20 +14,20 @@ jobs:
       matrix:
         arch: ["amd64", "i386"]
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
-        php-extensions: ['bcmath', 'gmp']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-extension: ['bcmath', 'gmp']
         exclude:
           # We are getting weird libxml2 failures on this combo
           - arch: "i386"
-            php-versions: 8.4
+            php-version: 8.4
 
-    name: "PHP ${{ matrix.php-versions }} (with ${{ matrix.php-extensions }}) test on ${{ matrix.operating-system }}/${{ matrix.arch }}"
+    name: "PHP ${{ matrix.php-version }} (with ${{ matrix.php-extension }}) test on ${{ matrix.operating-system }}/${{ matrix.arch }}"
     steps:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
-          extensions: "mbstring, intl, ${{ matrix.php-extensions }}"
+          php-version: ${{ matrix.php-version }}
+          extensions: "mbstring, intl, ${{ matrix.php-extension }}"
           tools: "composer, phpize"
 
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         arch: ["amd64", "i386"]
         operating-system: [ubuntu-latest]
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         php-extensions: ['bcmath', 'gmp']
     name: "PHP ${{ matrix.php-versions }} (with ${{ matrix.php-extensions }}) test on ${{ matrix.operating-system }}/${{ matrix.arch }}"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-1.12.0
+1.12.0 (2024-11-14)
 -------------------
 
 * Improve the error handling when the user tries to open a directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Improve the error handling when the user tries to open a directory
   with the pure PHP reader.
+* Improve the typehints on arrays in the PHPDocs.
 
 1.11.1 (2023-12-01)
 -------------------

--- a/README.md
+++ b/README.md
@@ -180,6 +180,6 @@ The MaxMind DB Reader PHP API uses [Semantic Versioning](https://semver.org/).
 
 ## Copyright and License ##
 
-This software is Copyright (c) 2014-2023 by MaxMind, Inc.
+This software is Copyright (c) 2014-2024 by MaxMind, Inc.
 
 This is free software, licensed under the Apache License, Version 2.0.

--- a/ext/php_maxminddb.h
+++ b/ext/php_maxminddb.h
@@ -15,7 +15,7 @@
 
 #ifndef PHP_MAXMINDDB_H
 #define PHP_MAXMINDDB_H 1
-#define PHP_MAXMINDDB_VERSION "1.11.1"
+#define PHP_MAXMINDDB_VERSION "1.12.0"
 #define PHP_MAXMINDDB_EXTNAME "maxminddb"
 
 extern zend_module_entry maxminddb_module_entry;

--- a/package.xml
+++ b/package.xml
@@ -14,19 +14,19 @@
         <email>goschwald@maxmind.com</email>
         <active>yes</active>
     </lead>
-    <date>2023-12-01</date>
+    <date>2024-11-14</date>
     <version>
-        <release>1.11.1</release>
-        <api>1.11.1</api>
+        <release>1.12.0</release>
+        <api>1.12.0</api>
     </version>
     <stability>
         <release>stable</release>
         <api>stable</api>
     </stability>
     <license uri="https://github.com/maxmind/MaxMind-DB-Reader-php/blob/main/LICENSE">Apache License 2.0</license>
-    <notes>* Resolve warnings when compiling the C extension.
-* Fix various type issues detected by PHPStan level. Pull request by
-  LauraTaylorUK. GitHub #160.</notes>
+    <notes>* Improve the error handling when the user tries to open a directory
+  with the pure PHP reader.
+* Improve the typehints on arrays in the PHPDocs.</notes>
     <contents>
         <dir name="/">
             <file role="doc" name="LICENSE"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,3 @@ parameters:
     paths:
         - src
         - tests
-    checkMissingIterableValueType: false
-

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="MaxMind DB Test Suite">
-            <directory suffix="Test.php">./tests/MaxMind/Db/Test/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/MaxMind/Db/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/MaxMind/Db/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="MaxMind DB Test Suite">
+      <directory suffix="Test.php">./tests/MaxMind/Db/Test/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/MaxMind/Db/Reader.php
+++ b/src/MaxMind/Db/Reader.php
@@ -149,8 +149,8 @@ class Reader
      *                                   if the database is invalid or there is an error reading
      *                                   from it
      *
-     * @return array an array where the first element is the record and the
-     *               second the network prefix length for the record
+     * @return array{0:mixed, 1:int} an array where the first element is the record and the
+     *                               second the network prefix length for the record
      */
     public function getWithPrefixLen(string $ipAddress): array
     {
@@ -174,6 +174,9 @@ class Reader
         return [$this->resolveDataPointer($pointer), $prefixLen];
     }
 
+    /**
+     * @return array{0:int, 1:int}
+     */
     private function findAddressInTree(string $ipAddress): array
     {
         $packedAddr = @inet_pton($ipAddress);

--- a/src/MaxMind/Db/Reader/Decoder.php
+++ b/src/MaxMind/Db/Reader/Decoder.php
@@ -63,6 +63,9 @@ class Decoder
         $this->switchByteOrder = $this->isPlatformLittleEndian();
     }
 
+    /**
+     * @return array<mixed>
+     */
     public function decode(int $offset): array
     {
         $ctrlByte = \ord(Util::read($this->fileStream, $offset, 1));
@@ -110,6 +113,8 @@ class Decoder
 
     /**
      * @param int<0, max> $size
+     *
+     * @return array{0:mixed, 1:int}
      */
     private function decodeByType(int $type, int $offset, int $size): array
     {
@@ -167,6 +172,9 @@ class Decoder
         }
     }
 
+    /**
+     * @return array{0:array<mixed>, 1:int}
+     */
     private function decodeArray(int $size, int $offset): array
     {
         $array = [];
@@ -247,6 +255,9 @@ class Decoder
         return $int;
     }
 
+    /**
+     * @return array{0:array<string, mixed>, 1:int}
+     */
     private function decodeMap(int $size, int $offset): array
     {
         $map = [];
@@ -260,6 +271,9 @@ class Decoder
         return [$map, $offset];
     }
 
+    /**
+     * @return array{0:int, 1:int}
+     */
     private function decodePointer(int $ctrlByte, int $offset): array
     {
         $pointerSize = (($ctrlByte >> 3) & 0x3) + 1;
@@ -378,6 +392,9 @@ class Decoder
         return $integerAsString;
     }
 
+    /**
+     * @return array{0:int, 1:int}
+     */
     private function sizeFromCtrlByte(int $ctrlByte, int $offset): array
     {
         $size = $ctrlByte & 0x1F;

--- a/src/MaxMind/Db/Reader/Metadata.php
+++ b/src/MaxMind/Db/Reader/Metadata.php
@@ -48,7 +48,7 @@ class Metadata
      * in that language as a UTF-8 string. May be undefined for some
      * databases.
      *
-     * @var array
+     * @var array<string, string>
      */
     public $description;
 
@@ -65,7 +65,7 @@ class Metadata
      * may contain data items that have been localized to some or all of
      * these languages. This may be undefined.
      *
-     * @var array
+     * @var array<string>
      */
     public $languages;
 
@@ -95,6 +95,9 @@ class Metadata
      */
     public $searchTreeSize;
 
+    /**
+     * @param array<string, mixed> $metadata
+     */
     public function __construct(array $metadata)
     {
         if (\func_num_args() !== 1) {

--- a/tests/MaxMind/Db/Test/Reader/DecoderTest.php
+++ b/tests/MaxMind/Db/Test/Reader/DecoderTest.php
@@ -291,6 +291,9 @@ class DecoderTest extends TestCase
         return $bytes;
     }
 
+    /**
+     * @return array<int, array<int>>
+     */
     public function generateLargeUint(int $bits): array
     {
         $ctrlByte = $bits === 64 ? 0x2 : 0x3;
@@ -384,6 +387,9 @@ class DecoderTest extends TestCase
         $this->validateTypeDecoding('uint128', $this->generateLargeUint(128));
     }
 
+    /**
+     * @param array<mixed> $tests
+     */
     private function validateTypeDecoding(string $type, array $tests): void
     {
         foreach ($tests as $expected => $input) {
@@ -391,6 +397,9 @@ class DecoderTest extends TestCase
         }
     }
 
+    /**
+     * @param array<mixed> $tests
+     */
     private function validateTypeDecodingList(string $type, array $tests): void
     {
         foreach ($tests as $test) {

--- a/tests/MaxMind/Db/Test/Reader/DecoderTest.php
+++ b/tests/MaxMind/Db/Test/Reader/DecoderTest.php
@@ -306,7 +306,14 @@ class DecoderTest extends TestCase
 
         for ($power = 1; $power <= $bits / 8; ++$power) {
             if (\extension_loaded('gmp')) {
-                $expected = gmp_strval(gmp_sub(gmp_pow('2', 8 * $power), '1'));
+                // This is to work around the limit added to gmp_pow here:
+                // https://github.com/php/php-src/commit/e0a0e216a909dc4ee4ea7c113a5f41d49525f02e
+                $v = 1;
+                for ($i = 0; $i < $power; $i++) {
+                    $v = gmp_mul($v, 256);
+                }
+
+                $expected = gmp_strval(gmp_sub($v, '1'));
             } elseif (\extension_loaded('bcmath')) {
                 $expected = bcsub(bcpow('2', (string) (8 * $power)), '1');
             } else {

--- a/tests/MaxMind/Db/Test/ReaderTest.php
+++ b/tests/MaxMind/Db/Test/ReaderTest.php
@@ -364,12 +364,12 @@ class ReaderTest extends TestCase
 
     public function testClose(): void
     {
+        $this->expectNotToPerformAssertions();
+
         $reader = new Reader(
             'tests/data/test-data/MaxMind-DB-test-decoder.mmdb'
         );
         $reader->close();
-
-        $this->assertTrue(true);
     }
 
     public function testCloseArgs(): void


### PR DESCRIPTION
- **Test on 8.3 and 8.4**
- **Bump release year**
- **Remove exclude that no longer exists**
- **Improve the type hints for arrays**
- **Don't test 8.4 on i386**
- **Make matrix naming more consistent**
- **Migration PHPUnit config**
- **Work around gmp_pow behavior change**
- **Set release date for 1.12.0**
