### PR TITLE
Restore declare_strict_types enforcement (STF-223)

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -15,6 +15,7 @@ return $config
         'array_syntax' => ['syntax' => 'short'],
         'combine_consecutive_unsets' => true,
         'concat_space' => [ 'spacing' => 'one'],
+        'declare_strict_types' => true,
         'explicit_string_variable' => false,
         'fopen_flags' => ['b_mode' => true],
         'heredoc_to_nowdoc' => true,

--- a/examples/benchmark.php
+++ b/examples/benchmark.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require __DIR__ . '/../autoload.php';
 
 use MaxMind\Db\Reader;


### PR DESCRIPTION
## Summary

- php-cs-fixer [v3.95.0 changed the `@Symfony:risky` preset](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9384) to apply `declare_strict_types` with `'strategy' => 'remove'`, which strips `declare(strict_types=1);` from every file on the next CI run.
- Override the rule with `'strategy' => 'enforce'` so the pre-v3.95 behavior is preserved and strict types stay declared.
- The fixer added `declare(strict_types=1);` to `examples/benchmark.php` — not public API, so this is not user-visible.

Closes STF-223.

## Test plan

- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff` clean locally
- [x] `vendor/bin/phpcs --standard=PSR2 src/` clean locally
- [x] `vendor/bin/phpstan analyze` clean locally
- [ ] `PHP Lints` CI job green on this PR