### PR TITLE
Use 'GeoIP'/'GeoLite' branding in documentation

### DIFF
--- a/src/MaxMind/Db/Reader.php
+++ b/src/MaxMind/Db/Reader.php
@@ -62,7 +62,7 @@ class Reader
 
     /**
      * Constructs a Reader for the MaxMind DB format. The file passed to it must
-     * be a valid MaxMind DB file such as a GeoIp2 database file.
+     * be a valid MaxMind DB file such as a GeoIP database file.
      *
      * @param string $database the MaxMind DB file to use
      *


### PR DESCRIPTION
Updates prose/documentation to refer to the products as "GeoIP"/"GeoLite" instead of "GeoIP2"/"GeoLite2". Technical identifiers (packages, class names, .mmdb filenames, edition IDs, the geolite.info hostname, URLs) and test fixtures are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)