### PR TITLE
Add #252 to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
   name (`maxminddb.lib` instead of `libmaxminddb.lib`) when building the
   extension. The `lib` prefix was removed in libmaxminddb 1.6.0. Pull
   request by Jean-Baptiste Nahan. GitHub #231.
+* Replaced `XtOffsetOf()` with `offsetof()`. The `XtOffsetOf()` alias has
+  been removed in PHP 8.6. Pull request by Remi Collet. GitHub #252.
 
 1.13.1 (2025-11-21)
 -------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the 1.14.0 changelog to reflect replacement of `XtOffsetOf()` with `offsetof()`.
  * Noted that the `XtOffsetOf()` alias is removed in PHP 8.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->